### PR TITLE
1.22.4 go version set (github action updated to match)

### DIFF
--- a/.github/workflows/run-gosec.yml
+++ b/.github/workflows/run-gosec.yml
@@ -30,7 +30,7 @@ jobs:
       # it seems like I cannot use the default setup from - https://github.com/marketplace/actions/gosec-security-checker#github-action
       # The working directory I am trying to use isn't being respected.
       - name: Install Gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.21.0
 
       - name: Run Gosec Security Scanner
         run: gosec ./...

--- a/README.md
+++ b/README.md
@@ -31,7 +31,25 @@ Using NodeJS v22.13.0
 
 Using Golang
 
+### Version
+
+[Limited by support version from DigitalOcean.](https://docs.digitalocean.com/products/app-platform/reference/buildpacks/go/)
+Specifically it is _App Platform uses version 192 of the Heroku Go Buildpack_
+[Direct list found here (for version _192_)](https://github.com/heroku/heroku-buildpack-go/blob/v192/data.json)
+
+[Version selection can be done via](https://go.dev/doc/manage-install)
+
+Latest version is: _1.22.4_
+
+Current:
+> go install golang.org/dl/go1.22.4@latest
+> go1.22.4 download
+
 Primary motivation is I have done similar in Python multiple times (Flask, Quart) and while I have created microservices within Golang, I have not used it for web API hosting.
+
+#### Gosec
+
+Last version compatible with _1.22.4_ should be [v2.21.0](https://github.com/securego/gosec/releases/tag/v2.21.0)
 
 ### Cron style aggregation/s
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module mini-farm-tracker
 
-go 1.22.12
+go 1.22.4
 
 require (
 	github.com/gin-contrib/cors v1.7.3


### PR DESCRIPTION
1.22.4 selected which is the max go supported version of the 192 version of the Heroku Go Buildpack 2. Selected Gosec version within the github actions selected which supports this go version