### PR TITLE
Purpose here was to continue the separation of concerns required for security. Allow Vercel (via the config) to handle security on the webui, add server limitation code within the server logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,14 @@ Ideal outcomes would be flat resource usage across App Platform and Mongo. (Agai
   - [x] Input validation
   - [x] Authentication - TODO as part of v2
 - [x] Encryption (passwords) TODO as part of v2 although would like to allow for 3rd party auth.
-- [x] Rate limiting considered however given its not a publically supplied API (just supplies website) not likely all that benefical.
-- [x] Concurrency limit added however doesn't actively deny the connection but rather logging spike so I can action.
+~~[x] Rate limiting considered however given its not a publically supplied API (just supplies website) not likely all that benefical.~~
+~~[x] Concurrency limit added however doesn't actively deny the connection but rather logging spike so I can action.~~
+- [x] Rate limiting and concurrency limitation added focused on routes which are not supported.
+  - This was prompted by some [`interesting`](#interesting-network-traffic) network traffic detected.
+  - **TODO** The concurrency limitation does not apply limitation across all instances rather on an instance basis
+    - This can be changed to:
+      - Use the redis to coordinate across instances, have to consider the tradeoffs.
+      - make further use of load balancer within DigitalOcean.
 - [x] Project scanned with `gosec`.
     > gosec ./... [within `server` directory.]
   - [x] Add github workflow to scan with gosec on `master` branch interactions.
@@ -465,3 +471,60 @@ Following [configuration path](https://golang.testcontainers.org/features/config
   - Hardware provided
   - [x] Gateway
   - [x] 2x ultrasonic sensors to measure depth in tanks.
+
+## Misc.
+
+<a id="interesting-network-traffic"></a>
+### Interesting network traffic
+
+1. Various attempts to grab the project
+
+  Feb 20 10:39:32 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 18:39:30 | 404 |      51.638µs | 206.221.176.253 | GET      "/backup.rar"
+  
+  Feb 20 10:39:32 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 18:39:30 | 404 |      47.694µs | 206.221.176.253 | GET      "/site.zip"
+  
+  Feb 20 10:39:32 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 18:39:30 | 404 |      44.674µs | 206.221.176.253 | GET      "/backup.zip"
+  
+  Feb 20 10:39:32 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 18:39:30 | 404 |      23.071µs | 206.221.176.253 | GET      "/api_mini-farm-tracker_io.rar"
+  
+  Feb 20 10:39:32 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 18:39:30 | 404 |      28.328µs | 206.221.176.253 | GET      "/website.zip"
+  
+  Feb 20 10:39:32 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 18:39:30 | 404 |      18.078µs | 206.221.176.253 | GET      "/api_mini-farm-tracker_io.zip"
+  
+  Feb 20 10:39:32 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 18:39:30 | 404 |      31.558µs | 206.221.176.253 | GET      "/site.rar"
+  
+  Feb 20 10:39:32 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 18:39:30 | 404 |      40.026µs | 206.221.176.253 | GET      "/api.mini-farm-tracker.io.zip"
+  
+  Feb 20 10:39:32 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 18:39:30 | 404 |      16.631µs | 206.221.176.253 | GET      "/website.rar"
+  
+  Feb 20 10:39:32 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 18:39:30 | 404 |      54.945µs | 206.221.176.253 | GET      "/apimini-farm-trackerio.rar"
+  
+  Feb 20 10:39:32 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 18:39:30 | 404 |      51.673µs | 206.221.176.253 | GET      "/apimini-farm-trackerio.zip"
+  
+  Feb 20 10:39:32 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 18:39:30 | 404 |      38.742µs | 206.221.176.253 | GET      "/api.mini-farm-tracker.io.rar"
+
+2. Various attempts to query for version control content
+  
+  Feb 20 05:46:17 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 13:46:15 | 404 |      61.282µs |    148.66.1.242 | GET      "/.git/HEAD"
+  
+  Feb 20 05:46:17 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 13:46:16 | 404 |      62.041µs |    148.66.1.242 | GET      "/.git/config"
+  
+  Feb 20 05:46:18 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 13:46:17 | 404 |      56.961µs |    148.66.1.242 | GET      "/.svn/entries"
+  
+  Feb 20 05:46:18 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 13:46:17 | 404 |      47.556µs |    148.66.1.242 | GET      "/.svn/wc.db"
+  
+  Feb 20 07:48:07 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 15:48:05 | 404 |      65.983µs |    148.66.1.242 | GET      "/.git/HEAD"
+  
+  Feb 20 07:48:08 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 15:48:06 | 404 |      55.219µs |    148.66.1.242 | GET      "/.git/config"
+  
+  Feb 20 07:48:08 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 15:48:06 | 404 |      74.434µs |    148.66.1.242 | GET      "/.svn/entries"
+  
+  Feb 20 07:48:08 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 15:48:07 | 404 |      65.825µs |    148.66.1.242 | GET      "/.svn/wc.db"
+  
+  Feb 20 09:00:48 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 17:00:46 | 404 |      63.688µs |    148.66.1.242 | GET      "/.git/HEAD"
+  
+  Feb 20 09:00:48 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 17:00:47 | 404 |       43.38µs |    148.66.1.242 | GET      "/.svn/entries"
+  
+  Feb 20 09:00:48 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 17:00:46 | 404 |      51.889µs |    148.66.1.242 | GET      "/.git/config"
+  
+  Feb 20 09:00:48 shark-app mini-farm-tracker-server [GIN] 2025/02/20 - 17:00:47 | 404 |      50.416µs |    148.66.1.242 | GET      "/.svn/wc.db"

--- a/server/core/gin-routing_test.go
+++ b/server/core/gin-routing_test.go
@@ -1,12 +1,16 @@
 package core
 
 import (
-	"context"
 	"encoding/json"
+	"fmt"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,15 +23,7 @@ func mapToJSONString(m any) (string, error) {
 }
 
 func TestSetupRouter(t *testing.T) {
-	db, deferFn := MockSetupMongo(context.TODO())
-	defer deferFn()
-
-	mongoDb := &MongoDatabaseImpl{Db: db}
-
-	server := &Server{
-		MongoDb: mongoDb,
-		Sensors: NewSyncCache[string, Sensor](),
-	}
+	server := &Server{}
 
 	router := SetupRouter(server)
 
@@ -35,9 +31,100 @@ func TestSetupRouter(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/ping", nil)
 	router.ServeHTTP(w, req)
 
-	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
 
 	expectedJson, err := mapToJSONString(map[string]string{"message": "pong"})
 	assert.ErrorIs(t, err, nil)
 	assert.Equal(t, expectedJson, w.Body.String())
+}
+
+func TestNoRouteSingleRequest(t *testing.T) {
+	server := &Server{}
+
+	router := SetupRouter(server)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/ping_random", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestNoRouteTriggerRateLimiter(t *testing.T) {
+	server := &Server{}
+
+	router := SetupRouter(server)
+
+	req, _ := http.NewRequest("GET", "/ping_random", nil)
+	for range NO_ROUTE_BURST {
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	}
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+}
+
+/*
+*
+Overall this was more to test functionality of the concurrency rather than be all that useful.
+By default the NoRoute finishes so quickly that it cannot be used to without arbitrarily adding sleep
+*/
+func TestNoRouteTriggerConcurrency(t *testing.T) {
+	server := &Server{}
+
+	router := SetupRouter(server)
+
+	// Idea where was that the semaphore within the `ConcurrencyLimiter` might not have time to setup the sem.
+	tempSlowNoRouteFn := func(c *gin.Context) {
+		time.Sleep(1 * time.Second)
+		c.Status(http.StatusNotFound)
+	}
+
+	noRoutes := []gin.HandlerFunc{}
+	noRoutes = append(noRoutes, noRoute()...)
+	noRoutes = append(noRoutes, tempSlowNoRouteFn)
+
+	router.NoRoute(noRoutes...)
+
+	additionalRequests := 7
+
+	returnStatus := make(chan int, NO_ROUTE_CONCURRENCY_LIMIT+additionalRequests)
+
+	var wg sync.WaitGroup
+	for i := range NO_ROUTE_CONCURRENCY_LIMIT + additionalRequests {
+		wg.Add(1)
+		go func(v int) {
+			defer wg.Done()
+
+			time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/ping_random", nil)
+			req.RemoteAddr = fmt.Sprintf("192.168.1.%d:1234", v+1)
+
+			router.ServeHTTP(w, req)
+
+			returnStatus <- w.Code
+		}(i)
+	}
+
+	wg.Wait()
+	close(returnStatus)
+
+	statuses := make(map[int]int)
+
+	for status := range returnStatus {
+		statuses[status] += 1
+	}
+
+	/**
+	At this point should have:
+	* (NO_ROUTE_CONCURRENCY_LIMIT) number of 404 return codes.
+	* (additionalRequests) number of 503
+	*/
+	assert.Equal(t, statuses[http.StatusNotFound], NO_ROUTE_CONCURRENCY_LIMIT)
+	assert.Equal(t, statuses[http.StatusServiceUnavailable], additionalRequests)
 }


### PR DESCRIPTION
1. Added both rate limiter (across IP addresses)
2. Added concurrency rate limiter.

Both of these are primarily focused Gins NoRoutes (which are all unassigned routes)