### PR TITLE
Refactor to ensure that calls to /metrics is constant regardless of what instance returns the response.

### DIFF
--- a/server/core/gin-routing.go
+++ b/server/core/gin-routing.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-contrib/gzip"
 	"github.com/gin-gonic/gin"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/sync/semaphore"
 	"golang.org/x/time/rate"
 )
@@ -286,7 +285,7 @@ func SetupRouter(server *Server) *gin.Engine {
 	})
 
 	log.Printf("Endpoint: %s not logged\n", METRICS_ENDPOINT)
-	promHandler := promhttp.Handler()
+	promHandler := server.Metrics.HandlerWithRedisUpdate()
 	r.GET(METRICS_ENDPOINT, gin.BasicAuth(gin.Accounts{
 		server.Envs.Metrics_username: server.Envs.Metrics_password,
 	}), gin.WrapH(promHandler))

--- a/server/core/gin-routing.go
+++ b/server/core/gin-routing.go
@@ -286,7 +286,7 @@ func SetupRouter(server *Server) *gin.Engine {
 
 	log.Printf("Endpoint: %s not logged\n", METRICS_ENDPOINT)
 	promHandler := server.Metrics.HandlerWithRedisUpdate()
-	r.GET(METRICS_ENDPOINT, gin.BasicAuth(gin.Accounts{
+	r.GET(METRICS_ENDPOINT, concurrencyForOtherRoutes, gin.BasicAuth(gin.Accounts{
 		server.Envs.Metrics_username: server.Envs.Metrics_password,
 	}), gin.WrapH(promHandler))
 


### PR DESCRIPTION
Each call to /metrics will result in a query within Redis to retrieve the current values. Given the overall lack of IoT devices and that the slowest updating device is per 10 minutes this is better than having a periodic sync approach.